### PR TITLE
Format deleted & inserted line with before selector

### DIFF
--- a/app/models/line.js
+++ b/app/models/line.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Object.extend({
+  contentWithoutPrefix: Ember.computed('content', function() {
+    return this.get('content').slice(1);
+  })
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -106,12 +106,28 @@ header h1 {
   color: rgba(0,0,0,0.3);
 }
 
+.line-code.comment::before {
+  content: "\\";
+}
+
 .line-code.deleted {
   background-color: #ffecec;
 }
 
+.line-code.deleted::before {
+  content: "-";
+}
+
 .line-code.inserted {
   background-color: #eaffea;
+}
+
+.line-code.inserted::before {
+  content: "+";
+}
+
+.line-code.unchanged::before {
+  content: " ";
 }
 
 .line-num {
@@ -144,41 +160,41 @@ header h1 {
 }
 
 .message {
-    margin: 0 auto;
-    width: 80%;
-    border: 1px solid;
-    padding: 1em;
-    text-transform: uppercase;
-    font-weight: bold;
+  margin: 0 auto;
+  width: 80%;
+  border: 1px solid;
+  padding: 1em;
+  text-transform: uppercase;
+  font-weight: bold;
 }
 
 .message:before {
-    content: attr(data-message-type);
+  content: attr(data-message-type);
 }
 
 .message.error {
-    border-color: rgb(237, 177, 177);
-    background-color: rgb(250, 222, 222);
-    color: rgb(176, 109, 109);
+  border-color: rgb(237, 177, 177);
+  background-color: rgb(250, 222, 222);
+  color: rgb(176, 109, 109);
 }
 
 .message * {
-    text-transform: none;
-    font-weight: normal;
-    color: initial;
+  text-transform: none;
+  font-weight: normal;
+  color: initial;
 }
 
 .message a {
-    text-decoration: none;
-    float: right;
+  text-decoration: none;
+  float: right;
 }
 
 .message.error a {
-    color: rgb(176, 109, 109);
+  color: rgb(176, 109, 109);
 }
 
 .message span {
-    margin-left: 1em;
+  margin-left: 1em;
 }
 
 .meta {
@@ -190,7 +206,7 @@ header h1 {
 }
 
 @media (max-width: 600px) {
-  body{
+  body {
     font-size: 12px;
   }
 

--- a/app/templates/patch.hbs
+++ b/app/templates/patch.hbs
@@ -9,7 +9,7 @@
           <tr>
             <td {{bind-attr class=":line-num type" data-line-num=deletedLineNum}}></td>
             <td {{bind-attr class=":line-num type" data-line-num=insertedLineNum}}></td>
-            <td {{bind-attr class=":line-code type"}}>{{content}}</td>
+            <td {{bind-attr class=":line-code type"}}>{{contentWithoutPrefix}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "rails-diff",
   "dependencies": {
     "handlebars": "~1.3.0",
-    "jquery": "^1.11.1",
+    "jquery": "~1.11.1",
     "ember": "1.8.1",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",

--- a/tests/unit/models/line-test.js
+++ b/tests/unit/models/line-test.js
@@ -1,0 +1,18 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('model:line');
+
+test('it exists', function(assert) {
+  var model = this.subject();
+  assert.ok(!!model);
+});
+
+test('it returns content without prefix', function(assert) {
+  var model = this.subject({
+    content: ' foo'
+  });
+  assert.equal(model.get('contentWithoutPrefix'), 'foo');
+});

--- a/tests/unit/utils/patch-splitter-test.js
+++ b/tests/unit/utils/patch-splitter-test.js
@@ -1,5 +1,6 @@
+/* global module */
+
 import {
-  module,
   test
 } from 'ember-qunit';
 
@@ -7,7 +8,69 @@ import patchSplitter from 'rails-diff/utils/patch-splitter';
 
 module('patchSplitter');
 
-var patch = "diff -ur v3.1.1/Gemfile v3.2.6/Gemfile\nindex 0a5b233..0ace91f 100644\n--- a/Gemfile\n+++ b/Gemfile\n@@ -1,9 +1,9 @@\n-source 'http://rubygems.org'\n+source 'https://rubygems.org'\n-gem 'rails', '3.1.2'\n+gem 'rails', '3.2.6'\n@@ -11,8 +11,12 @@ gem 'sqlite3'\n-  gem 'sass-rails',   '~> 3.1.5.rc.2'\n-  gem 'coffee-rails', '~> 3.1.1'\n+  gem 'sass-rails',   '~> 3.2.3'\n+  gem 'coffee-rails', '~> 3.2.1'\ndiff -ur v3.1.1/config/routes.rb v3.2.6/config/routes.rb\nindex 2c8e7db..f01137d 100644\n--- a/config/routes.rb\n+++ b/config/routes.rb\n@@ -54,5 +54,5 @@ App::Application.routes.draw do\n-  # match ':controller(/:action(/:id(.:format)))'\n+  # match ':controller(/:action(/:id))(.:format)'";
+var patch = [
+  'diff -Nr -U 1000 -x \'*.png\' generated/v5.1.0/Gemfile generated/v5.1.1/Gemfile',
+  '--- generated/v5.1.0/Gemfile\t2017-05-13 00:39:57.000000000 +0000',
+  '+++ generated/v5.1.1/Gemfile\t2017-05-13 00:39:57.000000000 +0000',
+  '@@ -1,54 +1,54 @@',
+  ' source \'https://rubygems.org\'',
+  '',
+  ' git_source(:github) do |repo_name|',
+  '   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")',
+  '   "https://github.com/#{repo_name}.git"',
+  ' end',
+  '',
+  '',
+  ' # Bundle edge Rails instead: gem \'rails\', github: \'rails/rails\'',
+  '-gem \'rails\', \'~> 5.1.0\'',
+  '+gem \'rails\', \'~> 5.1.1\'',
+  ' # Use sqlite3 as the database for Active Record',
+  ' gem \'sqlite3\'',
+  ' # Use Puma as the app server',
+  ' gem \'puma\', \'~> 3.7\'',
+  ' # Use SCSS for stylesheets',
+  ' gem \'sass-rails\', \'~> 5.0\'',
+  ' # Use Uglifier as compressor for JavaScript assets',
+  ' gem \'uglifier\', \'>= 1.3.0\'',
+  ' # See https://github.com/rails/execjs#readme for more supported runtimes',
+  ' # gem \'therubyracer\', platforms: :ruby',
+  '',
+  ' # Use CoffeeScript for .coffee assets and views',
+  ' gem \'coffee-rails\', \'~> 4.2\'',
+  ' # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks',
+  ' gem \'turbolinks\', \'~> 5\'',
+  ' # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder',
+  ' gem \'jbuilder\', \'~> 2.5\'',
+  ' # Use Redis adapter to run Action Cable in production',
+  ' # gem \'redis\', \'~> 3.0\'',
+  ' # Use ActiveModel has_secure_password',
+  ' # gem \'bcrypt\', \'~> 3.1.7\'',
+  '',
+  ' # Use Capistrano for deployment',
+  ' # gem \'capistrano-rails\', group: :development',
+  '',
+  ' group :development, :test do',
+  '   # Call \'byebug\' anywhere in the code to stop execution and get a debugger console',
+  '   gem \'byebug\', platforms: [:mri, :mingw, :x64_mingw]',
+  '   # Adds support for Capybara system testing and selenium driver',
+  '-  gem \'capybara\', \'~> 2.13.0\'',
+  '+  gem \'capybara\', \'~> 2.13\'',
+  '   gem \'selenium-webdriver\'',
+  ' end',
+  '',
+  ' group :development do',
+  '   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.',
+  '   gem \'web-console\', \'>= 3.3.0\'',
+  '   gem \'listen\', \'>= 3.0.5\', \'< 3.2\'',
+  '   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring',
+  '   gem \'spring\'',
+  '   gem \'spring-watcher-listen\', \'~> 2.0.0\'',
+  ' end',
+  '',
+  ' # Windows does not include zoneinfo files, so bundle the tzinfo-data gem',
+  ' gem \'tzinfo-data\', platforms: [:mingw, :mswin, :x64_mingw, :jruby]',
+  '',
+].join("\n");
 
 test('returns array', function(assert) {
   var result = patchSplitter("");
@@ -18,5 +81,5 @@ test('sets file paths', function(assert) {
   var result = patchSplitter(patch),
       paths = result.mapBy("filePath");
 
-  assert.deepEqual(paths, ["Gemfile", "config/routes.rb"]);
+  assert.deepEqual(paths, ["Gemfile"]);
 });


### PR DESCRIPTION
When copy/paste entire files/sections, both `-` & `+` symbols are part of the selection.

By using `::before` selector to mark corresponding lines, symbols are not part of the selection, therefore no need to remove those in your editor after copy-paste.

However, I'm not sure where `-` & `+` symbols are coming from so I guess they should be removed from the initial markup.

Fix inconsistent indentation as well.