### PR TITLE
Revert assertion to match result

### DIFF
--- a/tests/unit/utils/patch-splitter-test.js
+++ b/tests/unit/utils/patch-splitter-test.js
@@ -4,9 +4,9 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | patchSplitter');
 
-test('returns object', function(assert) {
+test('returns array', function(assert) {
   const result = patchSplitter('');
-  assert.ok(typeof result === 'object');
+  assert.ok(result instanceof Array);
 });
 
 test('sets file paths', function(assert) {


### PR DESCRIPTION
This should probably also return to how it was before changing the `patchSplitter` function.

Sorry that I made you work extra to revert those proposed changes!