### PR TITLE
Allow for easier copy/paste, by removing +/- characters from selection

### DIFF
--- a/app/models/diff.js
+++ b/app/models/diff.js
@@ -15,29 +15,35 @@ export default EmberObject.extend({
     let insertedLineNum = 1;
 
     return this.get('rawLines').map(function(line) {
+      let typeChar = line.substring(0, 1)
+      let content = line.substr(1);
       if (comment.test(line)) {
         return Line.create({
-          content: line,
+          content: content,
           type: 'comment',
+          typeChar: typeChar,
         });
       } else if (deleted.test(line)) {
         return Line.create({
-          content: line,
+          content: content,
           deletedLineNum: deletedLineNum++,
           type: 'deleted',
+          typeChar: typeChar,
         });
       } else if (inserted.test(line)) {
         return Line.create({
-          content: line,
+          content: content,
           insertedLineNum: insertedLineNum++,
           type: 'inserted',
+          typeChar: typeChar,
         });
       } else {
         return Line.create({
-          content: line,
+          content: content,
           deletedLineNum: deletedLineNum++,
           insertedLineNum: insertedLineNum++,
           type: 'unchanged',
+          typeChar: typeChar,
         });
       }
     });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -100,6 +100,13 @@ header h1 {
   text-indent: -7px;
   white-space: pre-wrap;
 }
+.line-char {
+  background-color: inherit;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
 
 .line-code.comment {
   background-color: #fafafa;

--- a/app/templates/patch.hbs
+++ b/app/templates/patch.hbs
@@ -14,7 +14,7 @@
           <tr>
             <td class="line-num {{line.type}}" data-line-num="{{line.deletedLineNum}}"></td>
             <td class="line-num {{line.type}}" data-line-num="{{line.insertedLineNum}}"></td>
-            <td class="line-code {{line.type}}">{{line.content}}</td>
+            <td class="line-code {{line.type}}"><span class="line-char">{{line.typeChar}}</span>{{line.content}}</td>
           </tr>
         {{/each}}
       </tbody>


### PR DESCRIPTION
Thanks for the great project, it's helped me multiple times move my rails apps to a more recent version :)

One thing that bothered me, was that the + and - characters were included when copy/pasting code. This pull request stops the +/- characters from being included when you copy/paste, making the overall process faster.

It just splits each line by the first character, and then ignores that first character using CSS `user-select: none;`